### PR TITLE
feat: add pipeline definition variable validation

### DIFF
--- a/src/azure.rs
+++ b/src/azure.rs
@@ -27,6 +27,28 @@ pub struct VariableValue {
     pub is_secret: Option<bool>,
 }
 
+/// Variable data from a pipeline definition
+#[derive(Debug, Deserialize)]
+pub struct PipelineVariableValue {
+    /// The variable value (may be None for secret variables)
+    pub value: Option<String>,
+    /// Whether the variable is secret (can be null in Azure DevOps API response)
+    #[serde(rename = "isSecret")]
+    pub is_secret: Option<bool>,
+    /// Whether the variable can be overridden at queue time
+    #[serde(rename = "allowOverride", default)]
+    pub allow_override: bool,
+}
+
+/// Pipeline info from az pipelines list
+#[derive(Debug, Deserialize)]
+pub struct PipelineInfo {
+    /// Pipeline ID
+    pub id: i32,
+    /// Pipeline name
+    pub name: String,
+}
+
 /// Client for interacting with Azure DevOps via Azure CLI
 pub struct AzureDevOpsClient {
     /// Azure DevOps organization URL or name
@@ -186,6 +208,164 @@ impl AzureDevOpsClient {
         let variable_names: Vec<String> = group_data.variables.keys().cloned().collect();
 
         Ok(variable_names)
+    }
+
+    /// Look up a pipeline ID by name
+    ///
+    /// Uses `az pipelines list --name` to find the pipeline, then extracts the ID.
+    /// This works around a bug in `az pipelines variable list --pipeline-name` which
+    /// fails to find pipelines by name, while `--pipeline-id` works correctly.
+    ///
+    /// # Arguments
+    /// * `pipeline_name` - The name of the pipeline
+    ///
+    /// # Returns
+    /// * `Result<i32>` - The pipeline ID if found
+    pub fn get_pipeline_id_by_name(&self, pipeline_name: &str) -> Result<i32> {
+        // Note: We don't use --name filter because it doesn't work reliably
+        // (returns empty results even for exact matches). Instead, we list all
+        // pipelines and filter locally.
+        let output = Command::new("az")
+            .args([
+                "pipelines",
+                "list",
+                "--organization",
+                &self.organization,
+                "--project",
+                &self.project,
+                "--output",
+                "json",
+            ])
+            .output()
+            .with_context(|| {
+                format!("Failed to execute 'az pipelines list' for pipeline '{pipeline_name}'")
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Azure CLI command failed when looking up pipeline '{pipeline_name}': {stderr}");
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let trimmed = stdout.trim();
+
+        // Check for empty response
+        if trimmed.is_empty() || trimmed == "[]" || trimmed == "null" {
+            anyhow::bail!("Pipeline '{pipeline_name}' not found");
+        }
+
+        // Parse the JSON response (array of pipelines)
+        let pipelines: Vec<PipelineInfo> = serde_json::from_str(trimmed).with_context(|| {
+            format!("Failed to parse Azure CLI response when looking up pipeline '{pipeline_name}'")
+        })?;
+
+        // Find exact match by name
+        let pipeline = pipelines
+            .iter()
+            .find(|p| p.name == pipeline_name)
+            .ok_or_else(|| anyhow::anyhow!("Pipeline '{pipeline_name}' not found"))?;
+
+        Ok(pipeline.id)
+    }
+
+    /// Fetch pipeline definition variables from Azure DevOps by name
+    ///
+    /// First resolves the pipeline name to an ID using `az pipelines list`,
+    /// then fetches variables using the ID. This works around a bug in the
+    /// Azure CLI where `--pipeline-name` doesn't work for `az pipelines variable list`.
+    ///
+    /// # Arguments
+    /// * `pipeline_name` - The name of the pipeline
+    ///
+    /// # Returns
+    /// * `Result<HashMap<String, PipelineVariableValue>>` - Map of variable name to value
+    pub fn get_pipeline_variables(
+        &self,
+        pipeline_name: &str,
+    ) -> Result<HashMap<String, PipelineVariableValue>> {
+        // First resolve name to ID (works around Azure CLI bug)
+        let pipeline_id = self.get_pipeline_id_by_name(pipeline_name)?;
+
+        // Then fetch variables using the ID (which works reliably)
+        self.get_pipeline_variables_by_id(pipeline_id)
+    }
+
+    /// Get variable names from a pipeline definition
+    ///
+    /// # Arguments
+    /// * `pipeline_name` - The name of the pipeline
+    ///
+    /// # Returns
+    /// * `Result<Vec<String>>` - List of variable names defined on the pipeline
+    pub fn get_pipeline_variable_names(&self, pipeline_name: &str) -> Result<Vec<String>> {
+        let variables = self.get_pipeline_variables(pipeline_name)?;
+        Ok(variables.keys().cloned().collect())
+    }
+
+    /// Fetch pipeline definition variables from Azure DevOps by pipeline ID
+    ///
+    /// # Arguments
+    /// * `pipeline_id` - The ID of the pipeline (more reliable than name)
+    ///
+    /// # Returns
+    /// * `Result<HashMap<String, PipelineVariableValue>>` - Map of variable name to value
+    pub fn get_pipeline_variables_by_id(
+        &self,
+        pipeline_id: i32,
+    ) -> Result<HashMap<String, PipelineVariableValue>> {
+        let output = Command::new("az")
+            .args([
+                "pipelines",
+                "variable",
+                "list",
+                "--pipeline-id",
+                &pipeline_id.to_string(),
+                "--organization",
+                &self.organization,
+                "--project",
+                &self.project,
+                "--output",
+                "json",
+            ])
+            .output()
+            .with_context(|| {
+                format!(
+                    "Failed to execute 'az pipelines variable list' for pipeline ID {pipeline_id}"
+                )
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Azure CLI command failed for pipeline ID {pipeline_id}: {stderr}");
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let trimmed = stdout.trim();
+
+        // Check for empty response (pipeline has no variables or doesn't exist)
+        if trimmed.is_empty() || trimmed == "{}" || trimmed == "null" {
+            return Ok(HashMap::new());
+        }
+
+        // Parse the JSON response
+        let variables: HashMap<String, PipelineVariableValue> =
+            serde_json::from_str(trimmed).with_context(|| {
+                format!("Failed to parse Azure CLI response for pipeline ID {pipeline_id}")
+            })?;
+
+        Ok(variables)
+    }
+
+    /// Get variable names from a pipeline definition by ID
+    ///
+    /// # Arguments
+    /// * `pipeline_id` - The ID of the pipeline
+    ///
+    /// # Returns
+    /// * `Result<Vec<String>>` - List of variable names defined on the pipeline
+    pub fn get_pipeline_variable_names_by_id(&self, pipeline_id: i32) -> Result<Vec<String>> {
+        let variables = self.get_pipeline_variables_by_id(pipeline_id)?;
+        Ok(variables.keys().cloned().collect())
     }
 }
 
@@ -362,5 +542,86 @@ mod tests {
 
         assert_eq!(var_value.value, Some("test-value".to_string()));
         assert_eq!(var_value.is_secret, None); // Explicit null becomes None
+    }
+
+    // Tests for PipelineVariableValue
+
+    #[test]
+    fn test_parse_pipeline_variables_response() {
+        let json_response = r#"{
+            "varName": {
+                "value": "the-value",
+                "isSecret": false,
+                "allowOverride": true
+            },
+            "secretVar": {
+                "value": null,
+                "isSecret": true,
+                "allowOverride": false
+            }
+        }"#;
+
+        let variables: HashMap<String, PipelineVariableValue> =
+            serde_json::from_str(json_response).expect("Failed to parse JSON");
+
+        assert_eq!(variables.len(), 2);
+        assert!(variables.contains_key("varName"));
+        assert!(variables.contains_key("secretVar"));
+
+        let var = variables.get("varName").unwrap();
+        assert_eq!(var.value, Some("the-value".to_string()));
+        assert_eq!(var.is_secret, Some(false));
+        assert!(var.allow_override);
+
+        let secret = variables.get("secretVar").unwrap();
+        assert!(secret.value.is_none());
+        assert_eq!(secret.is_secret, Some(true));
+        assert!(!secret.allow_override);
+    }
+
+    #[test]
+    fn test_parse_empty_pipeline_variables() {
+        let json_response = "{}";
+        let variables: HashMap<String, PipelineVariableValue> =
+            serde_json::from_str(json_response).expect("Failed to parse JSON");
+        assert!(variables.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pipeline_variable_minimal() {
+        // Minimal response with only value (other fields should default)
+        let json_response = r#"{
+            "minimalVar": {
+                "value": "test"
+            }
+        }"#;
+
+        let variables: HashMap<String, PipelineVariableValue> =
+            serde_json::from_str(json_response).expect("Failed to parse JSON");
+
+        let var = variables.get("minimalVar").unwrap();
+        assert_eq!(var.value, Some("test".to_string()));
+        assert_eq!(var.is_secret, None); // missing field becomes None
+        assert!(!var.allow_override); // defaults to false
+    }
+
+    #[test]
+    fn test_parse_pipeline_variable_with_null_is_secret() {
+        // Test that null isSecret (actual Azure DevOps response format) works
+        let json_response = r#"{
+            "helloPipeline": {
+                "allowOverride": true,
+                "isSecret": null,
+                "value": "I'm a pipeline variable"
+            }
+        }"#;
+
+        let variables: HashMap<String, PipelineVariableValue> =
+            serde_json::from_str(json_response).expect("Failed to parse JSON");
+
+        let var = variables.get("helloPipeline").unwrap();
+        assert_eq!(var.value, Some("I'm a pipeline variable".to_string()));
+        assert_eq!(var.is_secret, None); // null becomes None
+        assert!(var.allow_override);
     }
 }


### PR DESCRIPTION
Add --pipeline-id and --pipeline-name flags to enable validation of variables defined on the pipeline definition (set via Azure DevOps UI, not in YAML).

Variable validation now checks three sources in priority order:
1. Inline variables (defined in YAML)
2. Pipeline definition variables (set on pipeline)
3. Variable group variables

Includes workaround for Azure CLI bug where 'az pipelines variable list --pipeline-name' fails to find pipelines. The workaround calls 'az pipelines list' to resolve the name to an ID, then uses --pipeline-id which works reliably.

New structures:
- PipelineVariableValue: represents variables from pipeline definitions
- PipelineInfo: represents pipeline metadata (id, name)